### PR TITLE
Fix page issues when hiding unapproved levels

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -122,15 +122,19 @@ var app = new Vue({
       params: {}
     }, 
     computed: {
-      truncated: function() {
-        let sorted = this.sorted(this.search_results);
+      filtered: function() {
+        let levels = this.search_results;
         if(!this.showUnverifiedLevels && !this.searchQuery.includes('booster')) {
-          sorted = sorted.filter((doc) => doc.verified);
+          levels = levels.filter((doc) => doc.verified);
         }
+        return levels;
+      },
+      truncated: function() {
+        const sorted = this.sorted(this.filtered);
         return _.chunk(sorted, this.limit)[this.currentPage];
       },
       numberOfPages: function() {
-        return _.chunk(this.search_results, this.limit).length;
+        return _.chunk(this.filtered, this.limit).length;
       },
       currentPage: {
         get: function() {

--- a/bundle.js
+++ b/bundle.js
@@ -124,7 +124,6 @@ var app = new Vue({
     computed: {
       truncated: function() {
         let sorted = this.sorted(this.search_results);
-        let search_results;
         if(!this.showUnverifiedLevels && !this.searchQuery.includes('booster')) {
           sorted = sorted.filter((doc) => doc.verified);
         }

--- a/bundle.js
+++ b/bundle.js
@@ -124,7 +124,11 @@ var app = new Vue({
     computed: {
       truncated: function() {
         let sorted = this.sorted(this.search_results);
-        return _.chunk(this.search_results, this.limit)[this.currentPage];
+        let search_results;
+        if(!this.showUnverifiedLevels && !this.searchQuery.includes('booster')) {
+          sorted = sorted.filter((doc) => doc.verified);
+        }
+        return _.chunk(sorted, this.limit)[this.currentPage];
       },
       numberOfPages: function() {
         return _.chunk(this.search_results, this.limit).length;

--- a/index.html
+++ b/index.html
@@ -178,7 +178,6 @@
 
             <article 
             v-for="(level,index) in truncated"
-            v-show="level.verified || showUnverifiedLevels || searchQuery.includes('booster')"
             class="flex-1 flex flex-col
                 min-w-72 max-w-sm m-2
                 bg-gray-200 

--- a/main.js
+++ b/main.js
@@ -79,7 +79,10 @@ var app = new Vue({
     computed: {
       truncated: function() {
         let sorted = this.sorted(this.search_results);
-        return _.chunk(this.search_results, this.limit)[this.currentPage];
+        if(!this.showUnverifiedLevels && !this.searchQuery.includes('booster')) {
+          sorted = sorted.filter((doc) => doc.verified);
+        }
+        return _.chunk(sorted, this.limit)[this.currentPage];
       },
       numberOfPages: function() {
         return _.chunk(this.search_results, this.limit).length;

--- a/main.js
+++ b/main.js
@@ -77,15 +77,19 @@ var app = new Vue({
       params: {}
     }, 
     computed: {
-      truncated: function() {
-        let sorted = this.sorted(this.search_results);
+      filtered: function() {
+        let levels = this.search_results;
         if(!this.showUnverifiedLevels && !this.searchQuery.includes('booster')) {
-          sorted = sorted.filter((doc) => doc.verified);
+          levels = levels.filter((doc) => doc.verified);
         }
+        return levels;
+      },
+      truncated: function() {
+        const sorted = this.sorted(this.filtered);
         return _.chunk(sorted, this.limit)[this.currentPage];
       },
       numberOfPages: function() {
-        return _.chunk(this.search_results, this.limit).length;
+        return _.chunk(this.filtered, this.limit).length;
       },
       currentPage: {
         get: function() {


### PR DESCRIPTION
- There are now a consistent number of levels on each page, regardless of the number of unapproved levels.
  - The total number of pages has been reduced accordingly.