### PR TITLE
Fix level sorting, clicking behind header

### DIFF
--- a/bundle.css
+++ b/bundle.css
@@ -1014,6 +1014,10 @@ img {
   pointer-events: none;
 }
 
+.pointer-events-auto{
+  pointer-events: auto;
+}
+
 .fixed{
   position: fixed;
 }
@@ -1088,6 +1092,10 @@ img {
 
 .text-gray-900{
   color: #1a202c;
+}
+
+.text-red-600{
+  color: #e53e3e;
 }
 
 .text-orange-400{

--- a/bundle.js
+++ b/bundle.js
@@ -196,12 +196,18 @@ var app = new Vue({
         };
         let sorting_functions = {
           'score': (a, b) => {
+            if (a.score === b.score) {
+              return a.song.localeCompare(b.song);
+            }
             return a.score < b.score ? -1 : 1;
           },
           'last_updated': (a, b) => {
             return (moment(a.last_updated) > moment(b.last_updated) ? -1 : 1);
           },
           'song': (a, b) => {
+            if (a.song === b.song) {
+              return a.author.localeCompare(b.author);
+            }
             return a.song.localeCompare(b.song);
           },
           'difficulty': (a, b) => {
@@ -211,9 +217,15 @@ var app = new Vue({
               'Tough' : 2,
               'VeryTough' : 3
             };
+            if (difficultyMap[a.difficulty] === difficultyMap[b.difficulty]) {
+              return a.song.localeCompare(b.song);
+            }
             return difficultyMap[a.difficulty] < difficultyMap[b.difficulty] ? -1 : 1;
           },
           'author': (a, b) => {
+            if (a.author === b.author) {
+              return a.song.localeCompare(b.song);
+            }
             return a.author.localeCompare(b.author);
           },
           'sampler': _.constant(0)

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
     <!-- This div appears when loaded. -->
     <div v-if="state=='LOADED'" id="loaded_state">
 
-      <header class='fixed top-0 w-full z-10'>
+      <header class='fixed top-0 w-full z-10 pointer-events-none'>
         <!-- top part -->
-        <div class='flex justify-between items-center bg-gray-800 px-3 py-2'>
+        <div class='flex justify-between items-center bg-gray-800 px-3 py-2 pointer-events-auto'>
           <!-- display/hide boosters icon -->
           <div class='flex items-center'>
             <button v-on:click="boostersOpen = !boostersOpen" class="text-gray-400 hover:text-white">
@@ -49,7 +49,7 @@
           </div>
         </div>
         <!-- menu / right sidebar-->
-        <div v-show='trayOpen' class='bg-gray-800 px-3 pt-2 pb-4 sm:w-full sm:max-w-sm sm:float-right sm:clearfix sm:rounded-bl-lg sm:px-6'>
+        <div v-show='trayOpen' class='bg-gray-800 px-3 pt-2 pb-4 sm:w-full sm:max-w-sm sm:float-right sm:clearfix sm:rounded-bl-lg sm:px-6 pointer-events-auto'>
           <!-- pagination shows up in the sidebar on mobile -->
           <pagination class="sm:hidden"
           v-bind:current-page='currentPage' 

--- a/main.js
+++ b/main.js
@@ -151,12 +151,18 @@ var app = new Vue({
         };
         let sorting_functions = {
           'score': (a, b) => {
+            if (a.score === b.score) {
+              return a.song.localeCompare(b.song);
+            }
             return a.score < b.score ? -1 : 1;
           },
           'last_updated': (a, b) => {
             return (moment(a.last_updated) > moment(b.last_updated) ? -1 : 1);
           },
           'song': (a, b) => {
+            if (a.song === b.song) {
+              return a.author.localeCompare(b.author);
+            }
             return a.song.localeCompare(b.song);
           },
           'difficulty': (a, b) => {
@@ -166,9 +172,15 @@ var app = new Vue({
               'Tough' : 2,
               'VeryTough' : 3
             };
+            if (difficultyMap[a.difficulty] === difficultyMap[b.difficulty]) {
+              return a.song.localeCompare(b.song);
+            }
             return difficultyMap[a.difficulty] < difficultyMap[b.difficulty] ? -1 : 1;
           },
           'author': (a, b) => {
+            if (a.author === b.author) {
+              return a.song.localeCompare(b.song);
+            }
             return a.author.localeCompare(b.author);
           },
           'sampler': _.constant(0)


### PR DESCRIPTION
Two bugs fixed: making level sorting consistent and clicking behind the header when the settings menu is opened.

Alan900900900 reported a very strange occurrence with the levels site on Firefox (can't replicate on Chrome or Edge) where levels appear to get duplicated across pages.
https://discord.com/channels/296802696243970049/304720987319173121/815066044838051902

This is due to JavaScript's unstable array.sort().

Now, after the primary sort, equivalent levels are then sorted by their song (or their author, in the case of song being the primary sort). This makes level sorting consistent across browsers and pages. I blame Firefox.

------------------------------------------------------------------------------------------------------

When opening the settings menu, the area to the left of it becomes unclickable (e.g. the links to streamer setlist and Discord, also copying level links for the topmost row of levels).

The fix simply disables pointer-events on the header but keeps them enabled on the search bar and settings menu.