### PR TITLE
Saved search settings in browser, some fixes

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -206,7 +206,7 @@ var app = new Vue({
           },
           'song': (a, b) => {
             if (a.song === b.song) {
-              return a.author.localeCompare(b.author);
+              return a.author[0].localeCompare(b.author[0]);
             }
             return a.song.localeCompare(b.song);
           },
@@ -223,10 +223,10 @@ var app = new Vue({
             return difficultyMap[a.difficulty] < difficultyMap[b.difficulty] ? -1 : 1;
           },
           'author': (a, b) => {
-            if (a.author === b.author) {
+            if (a.author[0] === b.author[0]) {
               return a.song.localeCompare(b.song);
             }
-            return a.author.localeCompare(b.author);
+            return a.author[0].localeCompare(b.author[0]);
           },
           'sampler': _.constant(0)
         };
@@ -344,6 +344,31 @@ var app = new Vue({
             // first time loaded!
             localStorage.setItem("first_time","1");
             this.searchQuery = "booster=starter";
+          }
+
+          // Save settings before leaving the page
+          window.addEventListener('beforeunload', () => {
+            const search_settings = {
+              limit: this.limit,
+              sort_by: this.sort_by,
+              sort_direction: this.sort_direction,
+              display_type: this.display_type,
+              showAutoImportLinks: this.showAutoImportLinks,
+              showUnverifiedLevels: this.showUnverifiedLevels
+            };
+            localStorage.setItem('search_settings', JSON.stringify(search_settings));
+          });
+
+          // Load saved settings from previous session
+          const raw_settings = localStorage.getItem('search_settings');
+          if(raw_settings) {
+            const { limit, sort_by, sort_direction, display_type, showAutoImportLinks, showUnverifiedLevels } = JSON.parse(raw_settings);
+            this.limit = limit;
+            this.sort_by = sort_by;
+            this.sort_direction = sort_direction;
+            this.display_type = display_type;
+            this.showAutoImportLinks = showAutoImportLinks;
+            this.showUnverifiedLevels = showUnverifiedLevels;
           }
         })
         .catch( (err) => {

--- a/bundle.js
+++ b/bundle.js
@@ -364,7 +364,7 @@ var app = new Vue({
           if(raw_settings) {
             const { limit, sort_by, sort_direction, display_type, showAutoImportLinks, showUnverifiedLevels } = JSON.parse(raw_settings);
             this.limit = limit;
-            this.sort_by = sort_by;
+            this.sort_by = sort_by === 'sampler' ? 'last_updated' : sort_by;  // Sorting by "in order" doesn't make sense on initial view
             this.sort_direction = sort_direction;
             this.display_type = display_type;
             this.showAutoImportLinks = showAutoImportLinks;

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
                 <path fill="currentColor" d="M207.03 381.48L12.69 187.13a24 24 0 0 1 0-33.94l22.66-22.67a24 24 0 0 1 33.9-.04L224 284.51l154.75-154.03a24 24 0 0 1 33.9.04l22.66 22.67a24 24 0 0 1 0 33.94L240.97 381.48a24 24 0 0 1-33.94 0z"/>
               </svg>
             </div>
-            <span class='ml-1'>,
+            <span :hidden="sort_by === 'sampler'" class='ml-1'>,
               <a v-on:click='switchDirection' class='text-purple-300 font-bold hover:text-white hover:cursor-pointer'>
                 {{order_texts[sort_by][sort_direction]}}
               </a>

--- a/main.js
+++ b/main.js
@@ -319,7 +319,7 @@ var app = new Vue({
           if(raw_settings) {
             const { limit, sort_by, sort_direction, display_type, showAutoImportLinks, showUnverifiedLevels } = JSON.parse(raw_settings);
             this.limit = limit;
-            this.sort_by = sort_by;
+            this.sort_by = sort_by === 'sampler' ? 'last_updated' : sort_by;  // Sorting by "in order" doesn't make sense on initial view
             this.sort_direction = sort_direction;
             this.display_type = display_type;
             this.showAutoImportLinks = showAutoImportLinks;

--- a/main.js
+++ b/main.js
@@ -161,7 +161,7 @@ var app = new Vue({
           },
           'song': (a, b) => {
             if (a.song === b.song) {
-              return a.author.localeCompare(b.author);
+              return a.author[0].localeCompare(b.author[0]);
             }
             return a.song.localeCompare(b.song);
           },
@@ -178,10 +178,10 @@ var app = new Vue({
             return difficultyMap[a.difficulty] < difficultyMap[b.difficulty] ? -1 : 1;
           },
           'author': (a, b) => {
-            if (a.author === b.author) {
+            if (a.author[0] === b.author[0]) {
               return a.song.localeCompare(b.song);
             }
-            return a.author.localeCompare(b.author);
+            return a.author[0].localeCompare(b.author[0]);
           },
           'sampler': _.constant(0)
         };
@@ -299,6 +299,31 @@ var app = new Vue({
             // first time loaded!
             localStorage.setItem("first_time","1");
             this.searchQuery = "booster=starter";
+          }
+
+          // Save settings before leaving the page
+          window.addEventListener('beforeunload', () => {
+            const search_settings = {
+              limit: this.limit,
+              sort_by: this.sort_by,
+              sort_direction: this.sort_direction,
+              display_type: this.display_type,
+              showAutoImportLinks: this.showAutoImportLinks,
+              showUnverifiedLevels: this.showUnverifiedLevels
+            };
+            localStorage.setItem('search_settings', JSON.stringify(search_settings));
+          });
+
+          // Load saved settings from previous session
+          const raw_settings = localStorage.getItem('search_settings');
+          if(raw_settings) {
+            const { limit, sort_by, sort_direction, display_type, showAutoImportLinks, showUnverifiedLevels } = JSON.parse(raw_settings);
+            this.limit = limit;
+            this.sort_by = sort_by;
+            this.sort_direction = sort_direction;
+            this.display_type = display_type;
+            this.showAutoImportLinks = showAutoImportLinks;
+            this.showUnverifiedLevels = showUnverifiedLevels;
           }
         })
         .catch( (err) => {


### PR DESCRIPTION
Search settings are now saved in the browser and will be loaded on future visits.

Other fixes:
- Sorting by creator/title no longer errors silently without doing anything.
- Ascending and Descending options for "in order" sorting are now disabled to avoid confusion.
- The site will now load with "last_updated" if "in order" was the sort saved from the previous session.
	- This is because "in order" sorting makes no sense outside of boosters.